### PR TITLE
Adding support for domain name services using `namicorn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "crypto-js": "3.1.9-1",
         "history": "4.7.2",
         "moonlet-core": "git+https://github.com/cryptolandtech/moonlet-core.git",
+        "namicorn": "0.0.13",
         "preact": "8.4.2",
         "preact-async-route": "2.2.1",
         "preact-compat": "3.18.4",

--- a/src/app/pages/send/send.component.tsx
+++ b/src/app/pages/send/send.component.tsx
@@ -12,7 +12,8 @@ import {
     convertUnit,
     getDefaultFeeOptions,
     formatCurrency,
-    calculateFee
+    calculateFee,
+    getAddressFromName
 } from '../../utils/blockchain/utils';
 import { FeeOptions } from '../../utils/blockchain/types';
 import { translate } from '../../utils/translate';
@@ -108,7 +109,7 @@ export class SendPage extends Component<IProps, IState> {
                                 outlined
                                 label={translate('App.labels.recipient')}
                                 onChange={e =>
-                                    this.setState({ recipient: e.target.value, address: undefined })
+                                    this.setState({ recipient: this.getName(e.target.value), address: undefined })
                                 }
                                 onBlur={() => {
                                     // todo enforce this check
@@ -307,6 +308,10 @@ export class SendPage extends Component<IProps, IState> {
             return <span>{this.state.address}</span>;
         }
         return '';
+    }
+
+    public getName(name) {
+        return getAddressFromName(name);
     }
 
     public onFeeOptionsChange(feeOptions) {

--- a/src/app/utils/blockchain/utils.ts
+++ b/src/app/utils/blockchain/utils.ts
@@ -4,6 +4,7 @@ import { BLOCKCHAIN_INFO, BlockchainFeeType } from './blockchain-info';
 import { Blockchain } from 'moonlet-core/src/core/blockchain';
 import BigNumber from 'bignumber.js';
 import { IState } from '../../data';
+import Namicorn from 'namicorn';
 
 export const convertUnit = (
     blockchain: Blockchain,
@@ -158,4 +159,31 @@ export const getAccountFromState = (state: IState, blockchain: Blockchain, addre
     }
 
     return account;
+};
+
+export const getAddressFromName = (
+    name: string,
+    namicorn: Namicorn = new Namicorn({ debug: false, disableMatcher: true })
+) => {
+    let address: string = name;
+    const middlewares = {
+        eth: namicorn.middleware.ens(),
+        zil: namicorn.middleware.zns(),
+        rsk: namicorn.middleware.rns()
+    };
+    const nameService = name.split('.', 3)[2];
+    namicorn.use(middlewares[nameService]);
+
+    address = namicorn
+        .resolve(name)
+        .then(data => {
+            if (data) {
+                return data;
+            } else {
+                return address;
+            }
+        })
+        .catch(error => error);
+
+    return address;
 };


### PR DESCRIPTION
Adding support for .eth, .zil, .rsk domain name services.

- User can specify name instead of address and then the name will be immediately replaced by the address using proper resolver (using `namicorn`)

Fixes #123 